### PR TITLE
ツイート内容の更新

### DIFF
--- a/check_cases_and_make_tweet.py
+++ b/check_cases_and_make_tweet.py
@@ -45,6 +45,9 @@ def check_cases_and_make_tweet() -> None:
         for ind, added_case in enumerate(added_cases):
             tweet += f"{added_case}"
             if ind != len(added_cases) - 1:
+                if ind == 2:
+                    tweet += " など"
+                    break
                 tweet += ", "
         tweet += "\n"
         tweet += f"https://atcoder.jp/contests/{contest_name}/tasks/{task_name}\n"  # 末尾の場合、この改行はツイート時に消される


### PR DESCRIPTION
## WHY

- ツイート内容を改善したい
- 今のままだと文字数が半角280文字を超え、ツイートできない可能性がある

## WHAT

- 問題名は abc123_a よりも ABC123_A の方が見やすいので、この形式の場合、またその場合のみ、大文字にする
- テストケース名を書くのは1問あたり最大2ケースのみにし、3ケース以上の場合は「 など」で省略する。(以下の表記の文字数はすべて半角換算)
  - こうすると「以下の問題に新たなテストケースが追加されました。」で48文字、1問あたり長く見積もっても88文字 (問題名で10文字、テストケース名(カンマスペース含む) で25文字x2、URLで23文字 (URLは一律でそうなる)、「 など」で5文字) なので、1ツイートに2問分入る。
- 280文字を超える場合はツイートを分割することにする
  - 文字数を数え、

### 確認

ARC165_B の追加が未反映の状態でツイートをしないテストをし、正常に出力されることを確認
()
`tweets: ['以下の問題に新たなテストケースが追加されました。\nARC165_B: aftercontest_01.txt, aftercontest_02.txt など\nhttps://atcoder.jp/contests/arc165/tasks/arc165_b\n']`