### PR TITLE
`testcases.txt` から古い情報を削除するようにする

### DIFF
--- a/get_and_update_added_cases.py
+++ b/get_and_update_added_cases.py
@@ -158,6 +158,7 @@ def get_and_update_added_cases(password: str) -> list[tuple[str, str, list[str]]
         exist_data = ast.literal_eval(first_line)
 
     contest_names_and_times = get_contest_names_and_start_times()
+    new_data = {}
 
     print("確認するコンテストと開始時刻の一覧", contest_names_and_times)
     for contest_name, start_time in contest_names_and_times:
@@ -184,11 +185,11 @@ def get_and_update_added_cases(password: str) -> list[tuple[str, str, list[str]]
                 added_cases = sorted(list(testcases_only_after))
                 all_added_cases.append((contest_name, task_name, added_cases))
 
-            exist_data[(contest_name, task_name)] = testcases_after
+            new_data[(contest_name, task_name)] = testcases_after
 
     with open("testcases.txt", "w") as f:
         print("update testcases.txt")
-        f.write(str(exist_data))
+        f.write(str(new_data))
 
     return all_added_cases
 


### PR DESCRIPTION
## WHY

`testcases.txt` から 14 日以上経過したコンテストの問題のテストケース一覧を削除する処理を入れていなかったので、中身が増え続けてしまう。

## WHAT

`testcases.txt` 更新用の dict について、既存のものに上書きするのではなく、新たなものを作成する。
これにより、取得対象とならなかった (=14日以内でない) コンテストの情報は自動的に消える。

- [x] 10/28 17時の更新で、削除されたこと・GA が成功したこと・(新テストケースがないのに) ツイートがされていないことを確認
  - https://github.com/tomii9273/atcoder_after_contest_bot/actions/runs/6675711801
  - 更新コミット: 3f843b220a3c60f7bf797ddb920e16a09a7735ab