### PR TITLE
複数問題でケース追加された際に文が重複するバグ修正

### DIFF
--- a/check_cases_and_make_tweet.py
+++ b/check_cases_and_make_tweet.py
@@ -59,6 +59,7 @@ def check_cases_and_make_tweet() -> None:
     tweet_body = ""
 
     for contest_name, task_name, added_cases in all_added_cases:
+        tweet_body = ""
         assert added_cases != []
         if re.fullmatch("a[brg]c[0-9]{3}_[a-z]", task_name):  # 一般的な表記の場合は大文字の方が見やすいので変換
             task_name_in_tweet = task_name.upper()

--- a/check_cases_and_make_tweet.py
+++ b/check_cases_and_make_tweet.py
@@ -73,13 +73,13 @@ def check_cases_and_make_tweet() -> None:
                     break
                 tweet_body += ", "
         tweet_body += "\n"
-        tweet_body += f"https://atcoder.jp/contests/{contest_name}/tasks/{task_name}\n"  # 末尾の場合、この改行はツイート時に消される
+        tweet_body += f"https://atcoder.jp/contests/{contest_name}/tasks/{task_name}\n"  # これがツイートの末尾の場合、この改行は X 側で自動で消される
         tweet_bodies.append(tweet_body)
 
     tweets = []
     tweet = tweet_head
     for tweet_body in tweet_bodies:
-        if count_half_width_chars_as_tweet(tweet + tweet_body) > 275:  # 5 文字分安全マージン
+        if count_half_width_chars_as_tweet(tweet + tweet_body) > 275:  # 最大 280 文字。5 文字分安全マージン
             tweets.append(tweet)
             tweet = tweet_head + tweet_body
         else:

--- a/check_cases_and_make_tweet.py
+++ b/check_cases_and_make_tweet.py
@@ -56,7 +56,6 @@ def check_cases_and_make_tweet() -> None:
     tweet_head = "以下の問題に新たなテストケースが追加されました。\n"
 
     tweet_bodies = []
-    tweet_body = ""
 
     for contest_name, task_name, added_cases in all_added_cases:
         tweet_body = ""


### PR DESCRIPTION
## WHY

複数問題 (ARC176-A, B) でケース追加された際に、前者 (A問題) の文が重複した状態でツイートされた
https://x.com/AfterContestBot/status/1782425562717249708

## WHAT

ツイート文の初期化し忘れだったので修正。

## ToDo

- デバッグしやすくする。
  - コメントアウトなどをしなくても、簡単なコマンドで、`testcases.txt` の更新なしでツイートが再現できる状態にする。(今は追加ケースの取得しかできない)
  - ツイートを作る部分と、XのAPIで実際に投稿する部分を分離するのが良さそう。